### PR TITLE
fix #25

### DIFF
--- a/src/components/coinMarket/popularList/Item.tsx
+++ b/src/components/coinMarket/popularList/Item.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { Dimensions } from 'react-native';
 import styled, { css } from 'styled-components/native';
 import { baseTypes } from 'base-types';
+
 import { CoinMarketReturn } from '/lib/api/CoinGeckoReturnType';
-import { digitToFixed } from '/lib/utils';
-import { convertUnits } from '/lib/utils';
+import { digitToFixed, convertUnits } from '/lib/utils';
+import { exponentToNumber } from '/lib/utils/currencyFormat';
 import { currencyFormat, getCurrencySymbol } from '/lib/utils/currencyFormat';
 import useLocales from '/hooks/useLocales';
 import useGlobalTheme from '/hooks/useGlobalTheme';
+
 import Image from '/components/common/Image';
 import Text from '/components/common/Text';
 import WatchListIcon from '/components/common/WatchListIcon';
@@ -46,7 +48,7 @@ const ValueWithPercentage = ({ value, percentage, currency }: PercentageProps) =
     <Text fontML color100 right>
       { value >= 1000000 
         ? convertUnits(value, currency) 
-        : currencyFormat({ value, prefix: getCurrencySymbol(currency) })
+        : currencyFormat({ value: exponentToNumber(value), prefix: getCurrencySymbol(currency) })
       }
     </Text>
     <IncreaseDecreaseValue
@@ -68,7 +70,7 @@ const Item = ({
   const { currency } = useLocales();
   const { theme } = useGlobalTheme();
   const { id, symbol } = item;
-  
+
   return (
     <ItemContainer 
       onPress={() => onPressItem(item.id, item.symbol)} 
@@ -176,4 +178,3 @@ const ImageWrap = styled.View`
 const ValueWrap = styled.View`
   width: 100%;
 `
-

--- a/src/components/coinMarketDetail/overview/priceChart/Cursor.tsx
+++ b/src/components/coinMarketDetail/overview/priceChart/Cursor.tsx
@@ -32,7 +32,6 @@ interface CursorProps {
   PADDING: number
   highestPrice: number[]
   lowestPrice: number[]
-  price_24h_ago: number
   datumX: Animated.SharedValue<string>
   datumY: Animated.SharedValue<string[]> 
   datumYChangePercentage: Animated.SharedValue<string>
@@ -48,7 +47,6 @@ const Cursor = ({
   PADDING,
   highestPrice,
   lowestPrice,
-  price_24h_ago,
   datumX,
   datumY,
   datumYChangePercentage,
@@ -112,7 +110,7 @@ const Cursor = ({
 
     if(prevPoint !== i) {
       Haptics.selectionAsync();
-      const changePercentage = digitToFixed(100 * (currentPoint[1] - price_24h_ago) / price_24h_ago, 2);
+      const changePercentage = digitToFixed(100 * (currentPoint[1] - data[0][1]) / data[0][1], 2);
 
       datumX.value = `${ getFormatedDate(currentPoint[0]) }`
       datumY.value = [
@@ -187,7 +185,6 @@ export default Cursor;
 
 type WrapProps = Pick<CursorProps, 'CURSOR_SIZE'>
 
-const Container = styled.View``
 const CursorWrap = styled.View<WrapProps>`
   width: ${({ CURSOR_SIZE }) => CURSOR_SIZE }px;
   height: ${({ CURSOR_SIZE }) => CURSOR_SIZE }px;

--- a/src/components/coinMarketDetail/overview/priceChart/LineChart.tsx
+++ b/src/components/coinMarketDetail/overview/priceChart/LineChart.tsx
@@ -301,7 +301,6 @@ const LineChart = ({
               highestPrice={highestPrice}
               lowestPrice={lowestPrice}
               onCursorActiveChange={onIsCursorActiveChange}
-              price_24h_ago={price_24h_ago}
               datumX={datumX}
               datumY={datumY}
               datumYChangePercentage={datumYChangePercentage}


### PR DESCRIPTION
1. 코인 리스트에 price수치가 e표기법으로 표시 된 소수점을 포함하여 format 진행하였음.
2. price 차트에서 price change percentage 값의 바뀐 기준을 1day ago의 price값에서 차트 데이터의 가장 처음 값. 즉 가장 초기 price값으로 수정

closed #25 